### PR TITLE
Fix raid location links

### DIFF
--- a/core/js/raids.content.js
+++ b/core/js/raids.content.js
@@ -48,7 +48,7 @@ function printRaid(raid, pokeimg_suffix) {
 	raidInfos.append($('<td>',{id: 'raidLevel_'+raid.gym_id, text: '★'.repeat(raid.level)}));
 	raidInfos.append($('<td>',{id: 'raidTime_'+raid.gym_id, text: raid.starttime + ' - ' + raid.endtime}));
 	raidInfos.append($('<td>',{id: 'raidRemaining_'+raid.gym_id, class: 'pokemon-remaining'}).append($('<span>',{class: (raidStart < now ? 'current' : 'upcoming')})));
-	raidInfos.append($('<td>',{id: 'raidGym_'+raid.gym_id}).append($('<a>',{href: '/map/?lat=' + raid.latitude + '&lng=' + raid.longitude, text: raid.name})));
+	raidInfos.append($('<td>',{id: 'raidGym_'+raid.gym_id}).append($('<a>',{href: '/map/?lat=' + raid.latitude + '&lon=' + raid.longitude, text: raid.name})));
 
 	var details = '';
 	var raidPokemon = $('<div>',{class: 'pokemon-single'});


### PR DESCRIPTION
RM expects **lon=**, not **lng**, the links used the default longitude from RM and were off.

This still doesn't fix #297 and the links still don't work if the user has "Start map at location" turned on, because that setting has priority over the coordinates URL, so maybe Gmaps-URL would be preferred.